### PR TITLE
Add xmlns attribute to svg element

### DIFF
--- a/lib/Manhattan.js
+++ b/lib/Manhattan.js
@@ -82,7 +82,12 @@ class Manhattan extends React.Component {
     // const height = width ? width / aspectRatio : null;
     return (
       <div ref={measureRef}>
-        <svg width={width} height={height} ref={node => (this.svgRef = node)} />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={width}
+          height={height}
+          ref={node => (this.svgRef = node)}
+        />
       </div>
     );
   }

--- a/lib/PheWAS.js
+++ b/lib/PheWAS.js
@@ -29,6 +29,7 @@ class PheWAS extends Component {
     return (
       <div ref={measureRef}>
         <svg
+          xmlns="http://www.w3.org/2000/svg"
           width={outerWidth}
           height={outerHeight}
           ref={node => (this.svgRef = node)}


### PR DESCRIPTION
This PR adds the `xmlns` attribute to the SVG elements so that the downloaded svg files can be easily opened in the browser and visualized.