### PR TITLE
Add pixel jitter to fix d3-voronoi issue

### DIFF
--- a/lib/Manhattan.js
+++ b/lib/Manhattan.js
@@ -418,10 +418,12 @@ class Manhattan extends React.Component {
     translation
   ) {
     // create voronoi generator
+    // jitter: see https://github.com/d3/d3-voronoi/issues/12
+    const pixelJitter = () => Math.random() - 0.5;
     const voronoi = d3
       .voronoi()
-      .x(d => scaleChromosomes[d.chromosome].scale(d.position))
-      .y(d => scaleMinusLogPValue(0))
+      .x(d => scaleChromosomes[d.chromosome].scale(d.position) + pixelJitter())
+      .y(d => scaleMinusLogPValue(0) + pixelJitter())
       .extent([[-1, -1], [dataAreaWidth + 1, dataAreaHeight + 1]]);
 
     // render in own group


### PR DESCRIPTION
This PR adds jitter (up to 1 pixel) to the points passed to the voronoi generator. This is because d3-voronoi uses a Delauney triangulation which fails on point sets containing colinear points. See [this issue](https://github.com/d3/d3-voronoi/issues/12).