### PR TITLE
Make tooltips clickable

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-    "presets": ["env", "react"],
-    "plugins": ["babel-plugin-transform-object-rest-spread"]
+  "presets": ["env", "react"],
+  "plugins": [
+    "babel-plugin-transform-object-rest-spread",
+    "transform-class-properties"
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["env", "react"],
-  "plugins": ["babel-plugin-transform-object-rest-spread"]
+  "plugins": [
+    "babel-plugin-transform-object-rest-spread",
+    "transform-class-properties"
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
   "presets": ["env", "react"],
-  "plugins": [
-    "babel-plugin-transform-object-rest-spread",
-    "transform-class-properties"
-  ]
+  "plugins": ["babel-plugin-transform-object-rest-spread"]
 }

--- a/lib/Manhattan.js
+++ b/lib/Manhattan.js
@@ -64,7 +64,7 @@ class Manhattan extends React.Component {
   }
   _render() {
     // avoid errors on empty data or null width
-    const { data, handleClick, handleMouseover, handleMouseout } = this.props;
+    const { data, handleClick, handleMouseover } = this.props;
     const { width, height } = this._dimensions();
     if (
       !data ||
@@ -166,6 +166,15 @@ class Manhattan extends React.Component {
     );
 
     // data
+    this._renderLoci(
+      svg,
+      data.associations,
+      scaleChromosomes,
+      scaleMinusLogPValue,
+      handleClick,
+      chartIndex,
+      [theme.margin.left, theme.margin.top]
+    );
     this._renderLociVoronoi(
       svg,
       data.associations,
@@ -173,21 +182,9 @@ class Manhattan extends React.Component {
       scaleMinusLogPValue,
       handleClick,
       handleMouseover,
-      handleMouseout,
       chartIndex,
       dataAreaWidth,
       dataAreaHeight,
-      [theme.margin.left, theme.margin.top]
-    );
-    this._renderLoci(
-      svg,
-      data.associations,
-      scaleChromosomes,
-      scaleMinusLogPValue,
-      handleClick,
-      handleMouseover,
-      handleMouseout,
-      chartIndex,
       [theme.margin.left, theme.margin.top]
     );
   }
@@ -323,8 +320,6 @@ class Manhattan extends React.Component {
     scaleChromosomes,
     scaleMinusLogPValue,
     handleClick,
-    handleMouseover,
-    handleMouseout,
     chartIndex,
     translation
   ) {
@@ -344,20 +339,13 @@ class Manhattan extends React.Component {
     loci
       .enter()
       .append('line')
+      .attr('class', function(association) {
+        return `loci-${association.indexVariantId}`;
+      })
       .attr('stroke', theme.line.color)
       .attr('stroke-width', theme.line.thickness)
       .merge(loci)
       .on('click', handleClick)
-      .on('mouseover', function(d) {
-        const l = d3.select(this);
-        l.attr('stroke', theme.line.highlightColor);
-        handleMouseover(d, this);
-      })
-      .on('mouseout', function() {
-        const l = d3.select(this);
-        l.attr('stroke', theme.line.color);
-        handleMouseout();
-      })
       .transition()
       .attr('x1', d => scaleChromosomes[d.chromosome].scale(d.position))
       .attr('y1', scaleMinusLogPValue(0))
@@ -373,7 +361,6 @@ class Manhattan extends React.Component {
     scaleMinusLogPValue,
     handleClick,
     handleMouseover,
-    handleMouseout,
     chartIndex,
     dataAreaWidth,
     dataAreaHeight,
@@ -412,14 +399,7 @@ class Manhattan extends React.Component {
         handleClick(d.data);
       })
       .on('mouseover', function(d) {
-        const l = svg.selectAll('.loci line').filter(d2 => d2 === d.data);
-        l.attr('stroke', theme.line.highlightColor);
-        handleMouseover(d.data, l.node());
-      })
-      .on('mouseout', function(d) {
-        const l = svg.selectAll('.loci line').filter(d2 => d2 === d.data);
-        l.attr('stroke', theme.line.color);
-        handleMouseout();
+        handleMouseover(d.data);
       })
       .transition()
       .attr('d', function(d) {
@@ -456,7 +436,6 @@ class Manhattan extends React.Component {
 Manhattan.defaultProps = {
   handleClick: () => {},
   handleMouseover: () => {},
-  handleMouseout: () => {},
 };
 
 Manhattan = withContentRect('bounds')(Manhattan);

--- a/lib/PheWAS.js
+++ b/lib/PheWAS.js
@@ -50,7 +50,7 @@ class PheWAS extends Component {
 
   _render() {
     const { x, y } = this;
-    const { associations, handleMouseover, handleMouseout } = this.props;
+    const { associations, handleMouseover } = this.props;
     const { outerWidth, outerHeight } = this._dimensions();
 
     if (!outerWidth || !outerHeight) {
@@ -77,16 +77,7 @@ class PheWAS extends Component {
     this._renderStudiesAxis(chart, width, height, xAxis);
     this._renderSignificanceLine(chart, y, width, SIGNIFICANCE);
     this._renderDataPoints(chart, assocs);
-    this._renderVoronoi(
-      chart,
-      assocs,
-      x,
-      y,
-      width,
-      height,
-      handleMouseover,
-      handleMouseout
-    );
+    this._renderVoronoi(chart, assocs, x, y, width, height, handleMouseover);
   }
 
   _renderStudiesAxis(chart, width, height, xAxis) {
@@ -162,11 +153,12 @@ class PheWAS extends Component {
     const dataPoints = chart
       .selectAll('path.point')
       .data(assocs, assoc => assoc.studyId);
+
     dataPoints
       .enter()
       .append('path')
       .attr('class', function(assoc) {
-        return `point point-${assoc.studyId}`;
+        return `point loci-${assoc.studyId}`;
       })
       .attr('fill', theme.point.color)
       .attr('d', trianglePath)
@@ -181,16 +173,7 @@ class PheWAS extends Component {
     dataPoints.exit().remove();
   }
 
-  _renderVoronoi(
-    chart,
-    assocs,
-    x,
-    y,
-    width,
-    height,
-    handleMouseover,
-    handleMouseout
-  ) {
+  _renderVoronoi(chart, assocs, x, y, width, height, handleMouseover) {
     const voronoi = d3
       .voronoi()
       .x(d => x(d.studyId))
@@ -215,14 +198,7 @@ class PheWAS extends Component {
       .style('fill', 'none')
       .style('pointer-events', 'all')
       .on('mouseover', function(d) {
-        const point = d3.select(`.point-${d.data.studyId}`);
-        point.attr('fill', theme.point.highlightColor);
-        handleMouseover(d.data, this);
-      })
-      .on('mouseout', function(d) {
-        const point = d3.select(`.point-${d.data.studyId}`);
-        point.attr('fill', theme.point.color);
-        handleMouseout();
+        handleMouseover(d.data);
       });
 
     lociVoronoi.exit().remove();
@@ -231,7 +207,6 @@ class PheWAS extends Component {
 
 PheWAS.defaultProps = {
   handleMouseover: () => {},
-  handleMouseout: () => {},
 };
 
 export default withContentRect('bounds')(PheWAS);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,3 +4,4 @@ export { default as ManhattanFlat } from './ManhattanFlat';
 export { default as PheWAS } from './PheWAS';
 export { default as Regional } from './Regional';
 export { getCytoband, chromosomesWithCumulativeLengths } from './utils';
+export { default as theme } from './theme';

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,4 +4,4 @@ export { default as ManhattanFlat } from './ManhattanFlat';
 export { default as PheWAS } from './PheWAS';
 export { default as Regional } from './Regional';
 export { getCytoband, chromosomesWithCumulativeLengths } from './utils';
-export { default as theme } from './theme';
+export { default as withTooltip } from './withTooltip';

--- a/lib/withTooltip.js
+++ b/lib/withTooltip.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+import theme from './theme';
+
+const ATTR_MAP = {
+  phewas: 'fill',
+  manhattan: 'stroke',
+};
+
+const HIGHLIGHT_MAP = {
+  phewas: theme.point.highlightColor,
+  manhattan: theme.line.highlightColor,
+};
+
+const COLOR_MAP = {
+  phewas: theme.point.color,
+  manhattan: theme.line.color,
+};
+
+const ID_MAP = {
+  phewas: 'studyId',
+  manhattan: 'indexVariantId',
+};
+
+function withTooltip(WrappedComponent, ListTooltip, tableColumns, type) {
+  return class extends Component {
+    state = {
+      open: false,
+      anchorData: null,
+      anchorEl: null,
+    };
+
+    handleMouseOver = data => {
+      const { anchorEl } = this.state;
+      if (anchorEl) {
+        anchorEl.setAttribute(ATTR_MAP[type], COLOR_MAP[type]);
+      }
+
+      const loci = document.querySelector(`.loci-${data[ID_MAP[type]]}`);
+      loci.setAttribute(ATTR_MAP[type], HIGHLIGHT_MAP[type]);
+
+      this.setState({
+        open: true,
+        anchorData: data,
+        anchorEl: loci,
+      });
+    };
+
+    handleMouseLeave = () => {
+      const { anchorEl } = this.state;
+      if (anchorEl) {
+        anchorEl.setAttribute(ATTR_MAP[type], COLOR_MAP[type]);
+      }
+
+      this.setState({
+        open: false,
+        anchorData: null,
+        anchorEl: null,
+      });
+    };
+
+    render() {
+      const { anchorEl, anchorData, open } = this.state;
+      const dataList = anchorData
+        ? tableColumns.map(({ label, id, renderCell }) => ({
+            label,
+            value: renderCell ? renderCell(anchorData) : anchorData[id],
+          }))
+        : [];
+      return (
+        <div onMouseLeave={this.handleMouseLeave}>
+          <WrappedComponent
+            handleMouseover={this.handleMouseOver}
+            {...this.props}
+          />
+          <ListTooltip open={open} anchorEl={anchorEl} dataList={dataList} />
+        </div>
+      );
+    }
+  };
+}
+
+export default withTooltip;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.19",
   "description": "Open Targets charting library",
   "main": "build/index.js",
-  "author": "Gareth Peat",
+  "contributors": [
+    "Alfredo Miranda <alfredo@miranda.io>",
+    "Gareth Peat <garethpeat@gmail.com>"
+  ],
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
@@ -16,6 +19,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
@@ -66,6 +70,7 @@
     ]
   },
   "peerDependencies": {
+    "@material-ui/core": "^1.4.3",
     "d3": "^5.5.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.5",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
@@ -70,7 +69,6 @@
     ]
   },
   "peerDependencies": {
-    "@material-ui/core": "^1.4.3",
     "d3": "^5.5.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -654,6 +658,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
This PR helps in making the chart tooltips clickable. The charts now only make use of a `handleMouseover` callback.